### PR TITLE
docs: typo in readme for Nim example (VF-000)

### DIFF
--- a/nim/README.md
+++ b/nim/README.md
@@ -40,5 +40,5 @@ sending the email for tyler@voiceflow.com called "How was your day?". Is that co
 ...
 > Say something: yes
 successfully sent the email for tyler@voiceflow.com called "How was your day?"
-The end! Start me again with `npm start`
+The end!
 ```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

I noticed a typo, likely from copying over the README from the npmJS example, where the example program output includes `Start me again with `npm start`. 

This fixes that error in the README for the Nim example.

### Checklist

- [X] title of PR reflects the branch name
- [X] all commits adhere to conventional commits
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
