### PR TITLE
docs: add missing examples to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Getting started with the [Voiceflow API](https://www.voiceflow.com/developer) ha
 Use one of our examples to get setup in a matter of minutes:
 
 - [Node.js](./nodeJS/README.md) - A Node.js app that lets you interact with your project from the terminal
+- [Deno](./deno/README.md) - A Deno app that lets you interact with your project from the terminal
 - [HTML and jQuery](./HTML/README.md) - A simple webpage that displays messages in your browser
 - [Nim](./nim/README.md) - A Nim app that lets you interact with your project from the terminal
 - [Rust](./rust/README.md) - A Rust app that lets you interact with your project from the terminal
+- [Python](./python/README.md) - A Python app that lets you interact with your project from the terminal
 
 Want an example that isn't listed?
 [Open a GitHub issue](https://github.com/voiceflow/api-examples/issues/new) and we'll add it to the list.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Brief description. What is this change?

Adds the Python and Deno examples to the root README file for better visibility

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
